### PR TITLE
refactor: remove 'api' prefix from cart and promo code endpoints

### DIFF
--- a/src/main/java/cart/controller/CartController.java
+++ b/src/main/java/cart/controller/CartController.java
@@ -27,7 +27,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @RestController
-@RequestMapping("/api/carts")
+@RequestMapping("/carts")
 @RequiredArgsConstructor
 @Tag(name = "Cart Controller", description = "Handles cart"
         + " operations like add, update,"

--- a/src/main/java/cart/controller/PromoCodeController.java
+++ b/src/main/java/cart/controller/PromoCodeController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/admin/promocodes")
+@RequestMapping("/admin/promocodes")
 @RequiredArgsConstructor
 @Tag(name = "PromoCode Admin", description = "Manage promotional codes (Requires Admin Role)")
 @Slf4j


### PR DESCRIPTION
This pull request updates the API endpoint paths in the `CartController` and `PromoCodeController` classes to simplify and standardize the URL structure.

### Changes to API endpoint paths:

* [`src/main/java/cart/controller/CartController.java`](diffhunk://#diff-e72851e4f49d80c2011d03282bcca82dab6867f855723ffeb8d72e4df45187b9L30-R30): Updated the `@RequestMapping` annotation to remove the `/api` prefix, changing the base path from `/api/carts` to `/carts`.
* [`src/main/java/cart/controller/PromoCodeController.java`](diffhunk://#diff-6cf0b88dcbe97512fdd40c58a9567cec0ade0c069b61f0667faa91dbf24ba280L24-R24): Updated the `@RequestMapping` annotation to remove the `/api` prefix, changing the base path from `/api/admin/promocodes` to `/admin/promocodes`.