### PR TITLE
Fix cart problemssss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.github.Podzilla</groupId>
             <artifactId>podzilla-utils-lib</artifactId>
-            <version>1.1.11</version>
+            <version>v1.1.13</version>
 
         </dependency>
 

--- a/src/main/java/com/podzilla/cart/controller/PromoCodeController.java
+++ b/src/main/java/com/podzilla/cart/controller/PromoCodeController.java
@@ -1,5 +1,6 @@
 package com.podzilla.cart.controller;
 
+import com.podzilla.auth.annotations.AllowedRoles;
 import com.podzilla.cart.model.PromoCode;
 import com.podzilla.cart.service.PromoCodeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +23,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/admin/promocodes")
+@AllowedRoles({"ROLE_ADMIN"})
 @RequiredArgsConstructor
 @Tag(name = "PromoCode Admin", description = "Manage promotional codes (Requires Admin Role)")
 @Slf4j

--- a/src/main/java/com/podzilla/cart/service/CartService.java
+++ b/src/main/java/com/podzilla/cart/service/CartService.java
@@ -294,7 +294,7 @@ public class CartService {
                             + " Discount={}, Total={}, ConfirmationType={}",
                     cart.getId(), cart.getSubTotal(), cart.getDiscountAmount(),
                     cart.getTotalPrice(), confirmationType);
-            eventPublisher.publishEvent(EventsConstants.ORDER_PLACED, checkoutEvent);
+            eventPublisher.publishEvent(EventsConstants.CART_CHECKEDOUT, checkoutEvent);
 
             log.info("Checkout event published successfully for cartId: {}. Clearing cart.", cart.getId());
             cart.getItems().clear();

--- a/src/test/java/service/CartServiceTest.java
+++ b/src/test/java/service/CartServiceTest.java
@@ -343,12 +343,12 @@ class CartServiceTest {
         PromoCode promo = createTestPromoCode("SAVE10", PromoCode.DiscountType.PERCENTAGE, new BigDecimal("10"), null, null, true);
         when(promoCodeService.getActivePromoCode("SAVE10")).thenReturn(Optional.of(promo));
 
-        doNothing().when(eventPublisher).publishEvent(eq(EventsConstants.ORDER_PLACED), any(CartCheckedoutEvent.class));
+        doNothing().when(eventPublisher).publishEvent(eq(EventsConstants.CART_CHECKEDOUT), any(CartCheckedoutEvent.class));
 
         Cart result = cartService.checkoutCart(customerId, ConfirmationType.OTP, "", latitude, longitude, address);
 
         ArgumentCaptor<CartCheckedoutEvent> eventCaptor = ArgumentCaptor.forClass(CartCheckedoutEvent.class);
-        verify(eventPublisher).publishEvent(eq(EventsConstants.ORDER_PLACED), eventCaptor.capture());
+        verify(eventPublisher).publishEvent(eq(EventsConstants.CART_CHECKEDOUT), eventCaptor.capture());
         CartCheckedoutEvent publishedEvent = eventCaptor.getValue();
 
         assertEquals(customerId, publishedEvent.getCustomerId());
@@ -377,7 +377,7 @@ class CartServiceTest {
         Cart result = cartService.checkoutCart(customerId, ConfirmationType.SIGNATURE, signature, latitude, longitude, address);
 
         ArgumentCaptor<CartCheckedoutEvent> eventCaptor = ArgumentCaptor.forClass(CartCheckedoutEvent.class);
-        verify(eventPublisher).publishEvent(eq(EventsConstants.ORDER_PLACED), eventCaptor.capture());
+        verify(eventPublisher).publishEvent(eq(EventsConstants.CART_CHECKEDOUT), eventCaptor.capture());
         CartCheckedoutEvent publishedEvent = eventCaptor.getValue();
 
         assertEquals(ConfirmationType.SIGNATURE, publishedEvent.getConfirmationType());
@@ -393,7 +393,7 @@ class CartServiceTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatus());
         assertEquals("Signature is required for SIGNATURE confirmation type", ex.getMessage());
-verify(eventPublisher, never()).publishEvent(eq(EventsConstants.ORDER_PLACED), any(CartCheckedoutEvent.class));
+verify(eventPublisher, never()).publishEvent(eq(EventsConstants.CART_CHECKEDOUT), any(CartCheckedoutEvent.class));
     }
 
     @Test
@@ -405,7 +405,7 @@ verify(eventPublisher, never()).publishEvent(eq(EventsConstants.ORDER_PLACED), a
 
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatus());
         assertEquals("Cannot checkout an empty cart.", ex.getMessage());
-verify(eventPublisher, never()).publishEvent(eq(EventsConstants.ORDER_PLACED), any(CartCheckedoutEvent.class));
+verify(eventPublisher, never()).publishEvent(eq(EventsConstants.CART_CHECKEDOUT), any(CartCheckedoutEvent.class));
     }
 
     @Test
@@ -421,7 +421,7 @@ verify(eventPublisher, never()).publishEvent(eq(EventsConstants.ORDER_PLACED), a
         cart.setDiscountAmount(new BigDecimal(formattedBigZero));
 
         doThrow(new RuntimeException("Event publish error")).when(eventPublisher)
-                .publishEvent(eq(EventsConstants.ORDER_PLACED), any(CartCheckedoutEvent.class));
+                .publishEvent(eq(EventsConstants.CART_CHECKEDOUT), any(CartCheckedoutEvent.class));
 
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> cartService.checkoutCart(customerId, ConfirmationType.QR_CODE, null, latitude, longitude, address));


### PR DESCRIPTION
This pull request includes updates to dependencies, introduces role-based access control for the `PromoCodeController`, and modifies the event publishing logic in the cart checkout process. It also updates related unit tests to reflect the changes in event naming.

### Dependency Updates:
* Updated the `podzilla-utils-lib` dependency version from `1.1.11` to `v1.1.13` in `pom.xml` to incorporate the latest features or fixes.

### Role-Based Access Control:
* Added the `@AllowedRoles({"ROLE_ADMIN"})` annotation to the `PromoCodeController` to enforce that only users with the `ROLE_ADMIN` role can access the admin promotional codes endpoint. [[1]](diffhunk://#diff-67975a4b827579147ec9ea77ff72ce49670232f84dc59573ee467f46b3f0656fR3) [[2]](diffhunk://#diff-67975a4b827579147ec9ea77ff72ce49670232f84dc59573ee467f46b3f0656fR26)

### Event Publishing Logic:
* Changed the event name from `ORDER_PLACED` to `CART_CHECKEDOUT` in the `CartService` to better align with the cart checkout process.

### Unit Test Updates:
* Updated all relevant test methods in `CartServiceTest` to use the new event name `CART_CHECKEDOUT` instead of `ORDER_PLACED`. This ensures consistency with the updated logic in `CartService`. [[1]](diffhunk://#diff-135863529a67706f52c456290af04174604be59ca8d91bcda71b27ddbaaf2490L346-R351) [[2]](diffhunk://#diff-135863529a67706f52c456290af04174604be59ca8d91bcda71b27ddbaaf2490L380-R380) [[3]](diffhunk://#diff-135863529a67706f52c456290af04174604be59ca8d91bcda71b27ddbaaf2490L396-R396) [[4]](diffhunk://#diff-135863529a67706f52c456290af04174604be59ca8d91bcda71b27ddbaaf2490L408-R408) [[5]](diffhunk://#diff-135863529a67706f52c456290af04174604be59ca8d91bcda71b27ddbaaf2490L424-R424)